### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:edit, :update, :destroy]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -35,6 +35,12 @@ class ItemsController < ApplicationController
       render :edit, status: :unprocessable_entity
     end
   end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
+  end
+
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,9 +36,13 @@ class ItemsController < ApplicationController
     end
   end
 
-  def destroy
-    @item.destroy
-    redirect_to root_path
+  def destroy 
+    if current_user == @item.user
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
   end
 
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <p class="or-text">or</p>
       <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-      <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", @item, data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in? %>
       <p class="or-text">or</p>
       <%# 商品が売れていない場合はこちらを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <p class="or-text">or</p>
       <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
-      <%= link_to "削除", @item, data: {turbo_method: :delete}, class:"item-destroy" %>
+      <%= link_to "削除", item_path, data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in? %>
       <p class="or-text">or</p>
       <%# 商品が売れていない場合はこちらを表示しましょう %>


### PR DESCRIPTION
# What
商品削除機能の実装

# Why
ユーザーが不要な商品を手軽に削除できるようになる

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/bdaea0c3ea8517797c7d36604206f7d2
